### PR TITLE
Homepage

### DIFF
--- a/web/cms/templates/content/event.html
+++ b/web/cms/templates/content/event.html
@@ -1,4 +1,5 @@
 <perch:content id="date" type="date" time="true" label="Event date" required="true" order="2" suppress="true" />
+<perch:content id="eventDisplayDate" type="date" time="true" format="%s" label="Event Display Date" required="true" order="2" suppress="true" />
 <perch:content id="ticketSalesDate" type="date" time="true" format="%s" label="Ticket On Sale" required="true" order="2" suppress="true" />
 <perch:content id="titoCode" type="text" label="Tito Code (no Url)" order="3" suppress="true" />
 

--- a/web/cms/templates/content/event.html
+++ b/web/cms/templates/content/event.html
@@ -1,6 +1,6 @@
 <perch:content id="date" type="date" time="true" label="Event date" required="true" order="2" suppress="true" />
-<perch:content id="eventDisplayDate" type="date" time="true" format="%s" label="Event Display Date" required="true" order="2" suppress="true" />
-<perch:content id="ticketSalesDate" type="date" time="true" format="%s" label="Ticket On Sale" required="true" order="2" suppress="true" />
+<perch:content id="eventDisplayDate" type="date" time="true" format="%s" label="Announcement Date" required="true" order="2" suppress="true" />
+<perch:content id="ticketSalesDate" type="date" time="true" format="%s" label="Ticket Date" required="true" order="2" suppress="true" />
 <perch:content id="titoCode" type="text" label="Tito Code (no Url)" order="3" suppress="true" />
 
 <div datetime="<perch:content id="date" type="date" time="true" format="%Y-%m-%d 18:00" />">

--- a/web/cms/templates/content/event.html
+++ b/web/cms/templates/content/event.html
@@ -10,7 +10,7 @@
 
     <time class="time"><perch:template path="includes/svg/time.svg" />18:00</time>
 
-    <a href="#map" class="location"><perch:template path="includes/svg/location.svg" />Campus North</a>
+    <a href="#map" class="location"><perch:template path="includes/svg/location.svg" />The Bunker</a>
 
     <perch:if id="date" match="gte" value="{todaysDate}" format="%s">
         <perch:if  id="ticketSalesDate" match="lte" value="{todaysDate}" format="%s">

--- a/web/cms/templates/content/event_next.html
+++ b/web/cms/templates/content/event_next.html
@@ -33,3 +33,25 @@
     </div>
 
 </section>
+
+
+<perch:noresults>
+  <section class="event-promotion">
+    <section class="event-promotion" datetime="<perch:content id="nextEvent" type="date" time="true" format="%Y-%m-%d 18:00" />">
+
+        <span>Our next event&hellip;</span>
+
+        <h1><perch:content id="nextMonth" type="text" label="Title" required="true" title="true" order="1" /> event</h1>
+
+        <time class="date" data-day="<perch:content id="nextEvent" type="date" time="true" format="%d" />"><perch:template path="includes/svg/date.svg" /><perch:content id="nextEvent" type="date" time="true" format="%-d %B" /></time>
+
+        <time class="time"><perch:template path="includes/svg/time.svg" />18:00</time>
+
+        <a href="#map" class="location"><perch:template path="includes/svg/location.svg" />The Bunker</a>
+    </section>
+
+    <p>Event will be announced shortly.</p>
+
+    <a href="#mailing-list" class="button"> Join our mailing list for more details.</a>
+  </section>
+</perch:noresults>

--- a/web/cms/templates/content/event_next.html
+++ b/web/cms/templates/content/event_next.html
@@ -6,14 +6,14 @@
 <section class="event-promotion" datetime="<perch:content id="date" type="date" time="true" format="%Y-%m-%d 18:00" />">
 
       <span>Our next event&hellip;</span>
-    
+
     <h1><perch:content id="title" type="text" label="Title" required="true" title="true" order="1" /></h1>
 
     <time class="date" data-day="<perch:content id="date" type="date" time="true" format="%d" />"><perch:template path="includes/svg/date.svg" /><perch:content id="date" type="date" time="true" format="%-d %B" /></time>
 
     <time class="time"><perch:template path="includes/svg/time.svg" />18:00</time>
 
-    <a href="#map" class="location"><perch:template path="includes/svg/location.svg" />Campus North</a>
+    <a href="#map" class="location"><perch:template path="includes/svg/location.svg" />The Bunker</a>
 </section>
 
     <perch:content id="introduction" type="textarea" label="Introduction" markdown="true" help="Short version for home page" />
@@ -21,7 +21,7 @@
     <div class="event-promotion__buttons">
 
     <perch:content id="archived" />
-    
+
     <perch:if id="archived" match="neq" value="yes">
         <perch:if  id="ticketSalesDate" match="lte" value="{todaysDate}" format="%s">
                         <tito-button event="frontendne/<perch:content id="titoCode" />">Get a ticket</tito-button>

--- a/web/cms/templates/layouts/homepage/header.php
+++ b/web/cms/templates/layouts/homepage/header.php
@@ -6,17 +6,31 @@
         </a>
 
         <?php
+            $monthDate = date("1-m-Y", strtotime("+1 month"));
+            PerchSystem::set_var('todaysDate', date('U'));
+            PerchSystem::set_var('nextMonth', date("F", strtotime("+1 month")));
+            PerchSystem::set_var('nextEvent', date('d-m-Y', strtotime('first thursday', strtotime($monthDate))));
 
-            PerchSystem::set_vars(array('todaysDate'=>date('U')));
+
+            $filters = array(
+        array(
+          'filter'     => 'date',
+          'match'      => 'gte',
+          'value'      => date('Y-m-d')
+        ),
+        array(
+          'filter'     => 'eventDisplayDate',
+          'match'      => 'lte',
+          'value'      => date('Y-m-d H:i:s')
+        ),
+    );
 
             perch_collection('Events', [
                 'template'   => 'event_next.html',
                 'sort'       => 'date',
                 'sort-order' => 'ASC',
                 'count'      => 1,
-                'filter'     => 'date',
-                'match'      => 'gte',
-                'value'      => date('Y-m-d'),
+                'filter'     => $filters
             ]);
         ?>
 

--- a/web/cms/templates/pages/events/event.php
+++ b/web/cms/templates/pages/events/event.php
@@ -7,12 +7,25 @@
 
     PerchSystem::set_vars(array('todaysDate'=>date('U')));
 
+
+                $filters = array(
+            array(
+              'filter'     => 'slug',
+              'match'      => 'eq',
+              'value'    => perch_get('s'),
+            ),
+            array(
+              'filter'     => 'eventDisplayDate',
+              'match'      => 'lte',
+              'value'      => date('Y-m-d H:i:s')
+            ),
+        );
+
+
   // Page content
   perch_collection('Events', [
     'template' => 'event.html',
-    'filter'   => 'slug',
-    'match'    => 'eq',
-    'value'    => perch_get('s'),
+    'filter'   => $filters,
     'count'    => 1,
   ]);
 


### PR DESCRIPTION
This covers a couple of trello cards.

Feel free to update wording.

Scenarios:
1. When event has passed and no future event is supplied it will default to current month +1 as an event, and hopefully find the first Thursday of that month. (web/cms/templates/content/event.html)
2. Events now have a 'display date' this allows them to be hidden till they need to be announced, this works on the home page and actual event page. The event list page, currently is filtered by event date so shouldn't be an issue.

🐄🐄🐄🐄🐄🐄🐄🐄🐄
