### PR TITLE
Updated talk html so it no longer is limited to 200 characters

### DIFF
--- a/web/cms/templates/content/talk.html
+++ b/web/cms/templates/content/talk.html
@@ -8,7 +8,7 @@
   </perch:related>
 </select>
 
-<perch:content id="introduction" type="textarea" label="Introduction" count="chars" order="2" chars="200" append="…" size="xs" help="Keep this short! (max 200 characters)" />
+<perch:content id="introduction" type="textarea" label="Introduction" count="chars" order="2" size="xs" help="Keep this short! (max 200 characters)" />
 
 <h2>Video</h2>
 <perch:content id="video" divider-before="Media embed code" type="textarea" order="5" size="xs" label="Wistia link" html="true" help="Embed code from the 'Inline embed' tab" />


### PR DESCRIPTION
I'm not sure if it was better to remove the hint about max characters, but this fixes the truncating issue.
