### PR TITLE
Removed duplicate title tag from header template

### DIFF
--- a/web/cms/templates/layouts/head.php
+++ b/web/cms/templates/layouts/head.php
@@ -4,7 +4,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="UTF-8">
     <meta name="viewport" content="initial-scale=1, width=device-width" />
-    <title><?php perch_pages_title(); ?></title>
     <?php
         if (perch_layout_var('page', true) == 'event') {
             $collection = 'Events';


### PR DESCRIPTION
Current site has two page titles, so the first one is being picked up in the browser.

This removes the generic one i.e All speaker profiles are currently 'Speaker'