### PR TITLE
Stops speaker's page existing when not published

### DIFF
--- a/web/cms/templates/pages/speakers/speaker.php
+++ b/web/cms/templates/pages/speakers/speaker.php
@@ -5,9 +5,18 @@
     ]);
     perch_collection('Speakers', [
         'template' => 'profile.html',
-        'filter'   => 'slug',
-        'match'    => 'eq',
-        'value'    => perch_get('s'),
+        'filter'     => [
+          [
+            'filter' => 'slug',
+            'match'  => 'eq',
+            'value'  => perch_get('s'),
+          ],
+          [
+            'filter' => 'status',
+            'match'  => 'eq',
+            'value'  => 'published',
+          ],
+        ],
         'count'    => 1,
     ]);
     perch_collection('Talks', [


### PR DESCRIPTION
At the moment, when a speaker page is marked as draft, they don't appear in the speaker listing. The is good. But the speaker page itself  _does_ exist. Not a terrible thing. But! If the speaker is accidentally published, Google indexes the page, then it's removed, Google may still list it. Not good.

This PR stops the speaker page existing until it is published. And if it is subsequently unpublished a 404 is returned.